### PR TITLE
date parser and formatter override doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,10 @@ For example,
     import { Ng2DatetimePickerModule, DateTime } from 'ng2-datetime-picker';
 
     // Override Date object formatter
-    DateTime.formatDate = function(date: Date) {
-      moment(date).format('YYYY-MM-DD hh:mm:ss');
-    };
+    DateTime.formatDate = (date: Date) => moment(date).format('YYYY-MM-DD hh:mm:ss');
 
-    // // Override Date object parser
-    DateTime.parse = function(str: string) {
-      moment(str).toDate();
-    };
+    // Override Date object parser
+    DateTime.parse = (str: any) => moment(str).toDate();
 
     @NgModule({
       imports: [BrowserModule, FormsModule, Ng2DatetimePickerModule],


### PR DESCRIPTION
The examples were missing return statements so I changed them to the new ES6 arrow function syntax (implicit returns).

Also changed the argument type in the parse function from "string" to "any" as it was causing a red squiggly line in PhpStorm (Argument type string is not assignable to parameter type Date)