### PR TITLE
Fixed compatibility issue with TypeScript 1.8

### DIFF
--- a/src/datetime-picker.component.ts
+++ b/src/datetime-picker.component.ts
@@ -269,6 +269,11 @@ export class DateTimePickerComponent implements AfterViewInit {
     dt.setMilliseconds(0);
     return dt;
   }
+  
+  public set year (year) {}
+  public set month (month) {}
+  public set day (day) {}
+  public set today (today) {}
 
   public initDateTime (date:Date) {
     date = date || new Date();


### PR DESCRIPTION
Get accessors only will create readonly annotation when compiled with typescript 2.0 and doesn't work well with typescript 1.8

So I added Set accessors as well to avoid the readonly tag.

You can possibly get rid of the get accessors all together as I coudln't see it being used anywhere.
But instead, use function. Eg

```
public getCurrentYear() {}
public getCurrentMonth() {}
public getCurrentDay() {]
public today() {}
```
