### PR TITLE
Added option to have a separate parse format and date format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 *.log
+app/app.component.js

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For full example, please check `test` directory to see the example of;
 ## Override default style
 
 The default style is written in `src/ng2-datetime-picker.component.ts`. 
-This can be overwritten by giving more details css selector.
+This can be overwritten by giving a more detailed css selector.
  
 e.g., 
 
@@ -95,6 +95,15 @@ if you are not using [momentjs](http://momentjs.com/). If you use momentjs, you
 can use momentjs dateformat by adding the following in your html.
 
     <script src="moment-with-locales.min.js"></script>
+    
+If you are using moment and want to pass in a string date value in one format but display it in a different format
+you can use both date-format and parse-format:
+    
+    <input 
+          [(ngModel)]="date" 
+          ng2-datetime-picker
+          date-format="MM/DD/YYYY HH:mm"
+          parse-format="YYYY-MM-DD HH:mm:ss" />
 
 If you want to have your own date format without using momentjs, 
 please override `Ng2DateTime.parser` and `Ng2DateTime.formatDate` function.
@@ -119,7 +128,7 @@ For example,
     })
     export class AppModule { }
 
-In addition, you can also override other static variables of `Ng2Datetime` class. The following
+In addition, you can override other static variables of `Ng2Datetime` class. The following
 is the list of variables that you can override.
   
   | Variable        | Default
@@ -158,8 +167,11 @@ please send me email to `allenhwkim AT gmail.com` with your github id.
   * **date-only**,  true or false, default is false
   * **time-only**, true or false, default is false 
   * **close-on-select**, true or false. indicates to close ng2-datetime-picker when select a date. default: true
-  * **date-format**,  momentjs date format, e.g. YYYY-MM-DD hh:mm:ss
+  * **date-format**,  momentjs date format, e.g. YYYY-MM-DD hh:mm:ss.
     You need to include `moment` js in your html to use date-format.
+    `<script src="moment.min.js"></script>`
+  * **parse-format**,  momentjs date format used to parse a string input value, e.g. YYYY-MM-DD hh:mm:ss.
+    You need to include `moment` js in your html to use parse-format.
     `<script src="moment.min.js"></script>`
   * **first-day-of-week** start day of week, 0 is sunday
   * **default-value** a date selected when a popup opens, default the current date

--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -83,6 +83,18 @@ var templateStr = `
     </ng2-utils-5>
     <pre>{{templateStr | htmlCode:'ng2-utils-5'}}</pre>
    
+   <ng2-utils-7>
+      <input 
+        id="test7"
+        [(ngModel)]="dateWithTime" 
+        ng2-datetime-picker
+        date-format="MM/DD/YYYY HH:mm z"
+        parse-format="YYYY-MM-DDTHH:mm:ss"/>
+        dateWithTime: {{dateWithTime}}
+      <br/>
+    </ng2-utils-7>
+    <pre>{{templateStr | htmlCode:'ng2-utils-7'}}</pre>
+   
   </div>
 `;
 
@@ -107,6 +119,7 @@ export class AppComponent {
   minDate = new Date(2017, 0, 1);
   maxDate = new Date(2017, 11, 31);
   disabledDates = [new Date(2016, 11, 26), new Date(2016, 11, 27)];
+  dateWithTime = '2017-1-15T14:22:00-05:00';
 
   constructor(private fb: FormBuilder) { }
 

--- a/src/ng2-datetime-picker.directive.ts
+++ b/src/ng2-datetime-picker.directive.ts
@@ -32,6 +32,7 @@ Number.isNaN = Number.isNaN || function(value) {
 })
 export class Ng2DatetimePickerDirective implements OnInit, OnChanges {
   @Input('date-format')       dateFormat: string;
+  @Input('parse-format')	  parseFormat: string;
   @Input('date-only')         dateOnly: boolean;
   @Input('time-only')         timeOnly: boolean;
   @Input('close-on-select')   closeOnSelect: string;
@@ -304,7 +305,7 @@ export class Ng2DatetimePickerDirective implements OnInit, OnChanges {
   private getDate(arg: any): Date {
     let date: Date = <Date>arg;
     if (typeof arg === 'string') {
-      date =  Ng2Datetime.parseDate(arg, this.dateFormat);
+      date =  Ng2Datetime.parseDate(arg, this.parseFormat, this.dateFormat);
     }
     return date;
   }

--- a/src/ng2-datetime.ts
+++ b/src/ng2-datetime.ts
@@ -72,15 +72,25 @@ export class Ng2Datetime {
     }
   }
 
-  static parseDate(dateStr: string, dateFormat?: string): Date {
+  static parseDate(dateStr: string, parseFormat?: string, dateFormat?: string): Date {
     if (typeof moment === 'undefined') {
       dateStr = Ng2Datetime.removeTimezone(dateStr);
       dateStr = dateStr + Ng2Datetime.addDSTOffset(dateStr);
       return Ng2Datetime.parseFromDefaultFormat(dateStr);
-    } else if (dateFormat) {
-      let date = moment(dateStr, dateFormat).toDate();
-      if (isNaN(date.getTime())) { // if dateFormat and dateStr does not match
-        date = moment(dateStr).toDate(); //parse as ISO format
+    } else if (dateFormat || parseFormat) {
+      // try parse using each format because changing format programmatically calls this twice,
+      // once with string in parse format and once in date format
+      let formats = [];
+      if (parseFormat) {
+        formats.push(parseFormat);
+      }
+      if (dateFormat) {
+        formats.push(dateFormat);
+      }
+      let m = moment(dateStr, formats);
+      let date = m.toDate();
+      if (!m.isValid()) { // if moment is invalid
+        date = moment(dateStr, moment.ISO_8601).toDate(); // parse as ISO format
       }
       return date;
     } else {


### PR DESCRIPTION
I added the option to provide a parse format that is different from the date format. This is useful when passing in a date in a different format from the one that you want to display. For example, this allows the user to pass in a date string in ISO format but display it in `MM/DD/YYYY HH:mm z` format. I have added an example (ng2-utils-7) to your test app. Without `parseFormat`, opening the datepicker shows an incorrect date; with parse-format, the datepicker shows the correct date, and after selecting a new date the input is formatted according to the given `dateFormat`.