### PR TITLE
fixed typo minDate<->maxDate

### DIFF
--- a/src/ng2-datetime-picker.directive.ts
+++ b/src/ng2-datetime-picker.directive.ts
@@ -86,7 +86,7 @@ export class Ng2DatetimePickerDirective implements OnInit, OnChanges {
     }
 
     if (this.maxDate && typeof this.maxDate == 'string') {
-      let d = Ng2Datetime.parseDate(<string>this.minDate);
+      let d = Ng2Datetime.parseDate(<string>this.maxDate);
       this.maxDate = isNaN(d.getTime()) ? new Date() : d;
     }
 


### PR DESCRIPTION
Should fix #114 

There was a typo in the parseDate function.

Regards,